### PR TITLE
Removed eslint-loader

### DIFF
--- a/ErrorChecking/package.json
+++ b/ErrorChecking/package.json
@@ -18,7 +18,7 @@
     "babel-loader": "^8.0.6",
     "eslint": "^6.7.2",
     "eslint-config-airbnb-base": "^14.0.0",
-    "eslint-loader": "^3.0.3",
+    "eslint-webpack-plugin": "^2.5.0",
     "eslint-plugin-import": "^2.19.1",
     "webpack": "^4.28.4",
     "webpack-cli": "^3.2.1"


### PR DESCRIPTION
Replaced it with eslint-webpack-plugin since eslint-loader is deprecated.

<!-- This repository *does not* accept pull requests (PRs). All pull requests will be closed. See CONTRIBUTING.md for further details. -->
